### PR TITLE
Fix Error if there are Razor components same name in different namespaces

### DIFF
--- a/Blazor.Bindable/BindableHelpers.cs
+++ b/Blazor.Bindable/BindableHelpers.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Blazor.Bindable
 {
@@ -31,6 +32,14 @@ namespace Blazor.Bindable
             }}
         }}
 ";
+        }
+
+        public static string SanitizeClassNameForFile(string className)
+        {
+            foreach (char c in Path.GetInvalidFileNameChars())
+                className = className.Replace(c, '_');
+
+            return className;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ If have a property with the `Bindable` attribute in a `partial class`
 [Parameter, Bindable] public string TestPropertyName { get; set; }
 ```
 
+## Note for .NET 6 higher
+**The attribute must be on a property in a class file (.razor.cs).  It cannot be in the razor @code section**
+
 It will append the generate the following code in the project's analyzer (allowing you to use Roslyn intellisense for properties and whatnot).
 ```C#
 [Microsoft.AspNetCore.Components.Parameter] public Microsoft.AspNetCore.Components.EventCallback<string> TestPropertyNameChanged { get; set; }


### PR DESCRIPTION
Changing the `hintName` to be unique for Razor components with the same name in different namespaces.
Adding usage information to the README for .NET 6+.